### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,4 @@
 # config files
-#Ignore the git
-.git
-.gitignore
-**/.gitkeep
 **/.DS_Store
 .husky/
 .vscode/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# config files
+#Ignore the git
+.git
+.gitignore
+**/.gitkeep
+**/.DS_Store
+.husky/
+.vscode/
+.editorconfig
+.eslintrc
+.eslintignore
+.prettierignore
+.prettierrc
+.lintstagedrc
+.markdownlint.json
+.stylelintignore
+.stylelintrc
+commitlint.config.ts
+.dockerignore
+Dockerfile*
+docker-compose*.yml
+
+# ignore documentation
+LICENSE
+CHANGELOG.md
+README.md
+
+# pass env vars through docker-compose
+# or mount .env* in dev
+.env*
+env/
+dist/
+
+# named volumes
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+#BUILD APPLICATION STEP
+FROM node:18-alpine as build
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY package.json .
+COPY package-lock.json .
+
+RUN npm ci --verbose --no-optional
+
+COPY . .
+
+RUN npm run build
+
+#SERVE APPLICATION IN PRODUCTION
+FROM nginx:stable-alpine AS nginx
+
+COPY --from=build /usr/src/app/dist/ /usr/share/nginx/html/
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-#BUILD APPLICATION STEP
+# BUILD APPLICATION STEP
 FROM node:18-alpine as build
 
 RUN mkdir -p /usr/src/app
 
 WORKDIR /usr/src/app
+
+# Because at vite.config.ts we use "git rev-parse --short HEAD"
+RUN apk add git
 
 COPY package.json .
 COPY package-lock.json .
@@ -14,7 +17,7 @@ COPY . .
 
 RUN npm run build
 
-#SERVE APPLICATION IN PRODUCTION
+# SERVE APPLICATION IN PRODUCTION
 FROM nginx:stable-alpine AS nginx
 
 COPY --from=build /usr/src/app/dist/ /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm ci --verbose --no-optional
+RUN npm ci --verbose
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Add ?url=<toot url> to the end of the Mastopoet URL to generate links that immed
 - [ ] Support for non-mastodon links
 - [ ] Alt text generator
 
+## Building with docker
+You can use docker for deploying a production ready instance of Mastopoet. 
+
+You can build with:
+```console
+docker build -t mastopoet .
+```
+It will build the application and deploy in a nginx instance, when the image is builded you can run using:
+```console
+docker run -d -p 80:80 mastopoet
+```
+For more options, see [nginx container options at dockerhub](https://hub.docker.com/_/nginx).
 ## Credits
 
 - [Mastodon Bird UI](https://github.com/ronilaukkarinen/mastodon-bird-ui/) by Roni Laukkarinen, licensed under MIT


### PR DESCRIPTION
Hello! Thanks for building this awesome tool! This PR simples add docker support for easily building a production ready conatiner of the tool. The image builds the tool normally via NPM and deploy the built static website to a nginx instance. Also I've added to README.md instructions for using it! 
I'll be happy to awnser any questions or work at any changes needed.