### PR TITLE
Splitting Instance code for multi-instance support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import SearchForm from "./components/SearchForm";
 import { useObjectState } from "./utils/use-object-state";
 import OptionsEditor from "./components/OptionsEditor";
+import testParseUrl from "./instance/_main";
 
 // Main styles
 import "./styles/App.scss";
@@ -116,6 +117,7 @@ function App() {
 
       <SearchForm
         submitUrl={async (url) => {
+          await testParseUrl(url);
           setMessage("");
           try {
             const response = await submitUrl(url);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
 import SearchForm from "./components/SearchForm";
 import { useObjectState } from "./utils/use-object-state";
 import OptionsEditor from "./components/OptionsEditor";
-import testParseUrl from "./instance/_main";
+import fetchPost from "./instance/_main";
 
 // Main styles
 import "./styles/App.scss";
@@ -117,10 +117,9 @@ function App() {
 
       <SearchForm
         submitUrl={async (url) => {
-          await testParseUrl(url);
           setMessage("");
           try {
-            const response = await submitUrl(url);
+            const response = await fetchPost(url);
             setPost(response);
             setHeight(defaultHeight);
             setWidth(defaultWidth);

--- a/src/instance/BaseInstance.ts
+++ b/src/instance/BaseInstance.ts
@@ -1,0 +1,14 @@
+import { Post } from "../components/PostItem";
+
+export default class BaseInstance {
+  public url: URL = new URL("https://example.com");
+  public postId: string = "";
+  public async execute(): Promise<Post> {
+    throw new Error("Not implemented");
+  }
+
+  constructor (url: URL, postId: string) {
+    this.url = url;
+    this.postId = postId;
+  }
+}

--- a/src/instance/Mastodon.ts
+++ b/src/instance/Mastodon.ts
@@ -1,0 +1,9 @@
+import { Post } from "../components/PostItem";
+import BaseInstance from "./BaseInstance";
+
+export default class MastodonInstance extends BaseInstance {
+  public async execute(): Promise<any> {
+    console.log("Hello world! [Mastodon]");
+    return "";
+  }
+}

--- a/src/instance/Misskey.ts
+++ b/src/instance/Misskey.ts
@@ -1,0 +1,9 @@
+import { Post } from "../components/PostItem";
+import BaseInstance from "./BaseInstance";
+
+export default class MisskeyInstance extends BaseInstance {
+  public async execute(): Promise<any> {
+    console.log("Hello world! [Misskey]");
+    return "";
+  }
+}

--- a/src/instance/Misskey.ts
+++ b/src/instance/Misskey.ts
@@ -1,9 +1,7 @@
-import { Post } from "../components/PostItem";
 import BaseInstance from "./BaseInstance";
 
-export default class MisskeyInstance extends BaseInstance {
+export default class MastodonInstance extends BaseInstance {
   public async execute(): Promise<any> {
-    console.log("Hello world! [Misskey]");
-    return "";
+    throw new Error("Misskey support not implemented")
   }
 }

--- a/src/instance/_main.ts
+++ b/src/instance/_main.ts
@@ -1,8 +1,10 @@
 import { Post } from '../components/PostItem';
 import BaseInstance from './BaseInstance';
-import MastodonInstance from "./Mastodon";
-import MisskeyInstance from './Misskey';
+import MisskeyInstance from "./Misskey";
+import MastodonInstance from './Mastodon';
 
+// Since all script on ReactJS will be imported to frontend,
+// we cannot dynamically import them using File System NodeJS.
 type InstanceListType = [typeof BaseInstance, RegExp[]][]
 const Instances: InstanceListType = [
   [MastodonInstance, [
@@ -16,15 +18,19 @@ const Instances: InstanceListType = [
 export default async function(inputURL: string): Promise<Post> {
   return new Promise((resolve, reject) => {
     const url = new URL(inputURL);
+    let found = false;
     Instances.find( ([instance, reg]) => {
       return reg.some(x => {
         const match = url.pathname.match(x)
         if (!match) return;
+        if (found) return;
 
         const postId = match[1];
         const initInstance = new (instance)(url, postId);
         initInstance.execute().then(res => resolve(res)).catch(err => reject(err))
+        found = true
       });
     });
+    if (!found) reject(new Error('Invalid URL'))
   });
 }

--- a/src/instance/_main.ts
+++ b/src/instance/_main.ts
@@ -1,0 +1,30 @@
+import { Post } from '../components/PostItem';
+import BaseInstance from './BaseInstance';
+import MastodonInstance from "./Mastodon";
+import MisskeyInstance from './Misskey';
+
+type InstanceListType = [typeof BaseInstance, RegExp[]][]
+const Instances: InstanceListType = [
+  [MastodonInstance, [
+    /^\/@\w+(?:@[\w-.]+)?\/(\d+)$/, // instace.social/@user/postid
+    /^\/users\/\w+(?:@[\w-.]+)?\/statuses\/(\d+)$/, // instance.social/users/user/statuses/postid
+  ]],
+  [MisskeyInstance, [
+    /^\/notes\/(\w+)$/, // instace.social/notes/postid
+  ]]
+];
+export default async function(inputURL: string): Promise<Post> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(inputURL);
+    Instances.find( ([instance, reg]) => {
+      return reg.some(x => {
+        const match = url.pathname.match(x)
+        if (!match) return;
+
+        const postId = match[1];
+        const initInstance = new (instance)(url, postId);
+        initInstance.execute().then(res => resolve(res)).catch(err => reject(err))
+      });
+    });
+  });
+}

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -6,6 +6,9 @@ const POST_REGEXES = [
   /^\/users\/\w+(?:@[\w-.]+)?\/statuses\/(\d+)$/, // instance.social/users/user/statuses/postid
 ];
 
+/**
+ * @deprecated Replacing with multi-instance support 
+ */
 export function parseUrl(inputURL: string) {
   try {
     const url = new URL(inputURL);
@@ -29,6 +32,9 @@ export function parseUrl(inputURL: string) {
   }
 }
 
+/**
+ * @deprecated Replacing with multi-instance support 
+ */
 export const getPostApiPath = (id: string) => `/api/v1/statuses/${id}`;
 
 export const truncateString = (str: string, num: number) => {
@@ -40,6 +46,9 @@ export const truncateString = (str: string, num: number) => {
   }
 };
 
+/**
+ * @deprecated Replacing with multi-instance support 
+ */
 export async function mastodonStatusToPost(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -134,6 +143,9 @@ export function downloadURI(uri: string, name: string) {
   document.body.removeChild(link);
 }
 
+/**
+ * @deprecated Replacing with multi-instance support 
+ */
 export async function submitUrl(url: string) {
   const urlParsed = parseUrl(url);
   if (!urlParsed) throw new Error("Invalid Mastodon post URL");


### PR DESCRIPTION
# Description

Making another folder called `instance` on project to support multi-instance with limitation from ReactJS because it cannot using File System on the front-end. In the folder it have structure:
- `_main.ts` -> Single importer for instance
- `BaseInstance.ts` -> Class templating for instance
- `Mastodon.ts` & `Misskey.ts` -> Self explanation

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)