### PR TITLE
Misskey/Firefish "mini" compatibility.

### DIFF
--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -162,7 +162,7 @@ export default function PostItem({
         </div>
       )}
       {
-        post.reactions && <div className="action-bar" style={{maxWidth: '3em'}}>
+        post.reactions && <div className="action-bar" style={{flexWrap: 'wrap'}}>
           {
             post.reactions?.map((val, index) => <div key={index} className="emoji-reaction" style={{
               backgroundColor: '#2a2c38', margin: '0.5rem', padding: '0.3rem', display: 'flex', alignItems: 'center', borderRadius: '5px'

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -19,6 +19,13 @@ export interface Post {
     votesCount: number;
     percentage: number;
   }[];
+  reactions?: Reactions[];
+}
+
+export interface Reactions {
+  value?: string;
+  url?: string;
+  count: number;
 }
 
 export interface Attachment {
@@ -154,6 +161,19 @@ export default function PostItem({
           ))}
         </div>
       )}
+      {
+        post.reactions && <div className="action-bar" style={{maxWidth: '3em'}}>
+          {
+            post.reactions?.map((val, index) => <div key={index} className="emoji-reaction" style={{
+              backgroundColor: '#2a2c38', margin: '0.5rem', padding: '0.3rem', display: 'flex', alignItems: 'center', borderRadius: '5px'
+            }}>
+              { val.value && <span>{val.value}</span> }
+              { val.url && <img src={val.url} style={{maxWidth: '20px', objectFit: 'cover'}} /> }
+              <span style={{ marginLeft: '0.45rem' }}>{ val.count }</span>
+            </div>)
+          }
+        </div>
+      }
       <div className={`action-bar action-bar-${interactionsPref}`}>
         <span className="action-bar-datetime">{formatDate(date)}</span>
         <div className="action">
@@ -166,11 +186,13 @@ export default function PostItem({
           <span className="action-counter">{boosts}</span>
           <span className="action-label">Boosts</span>
         </div>
-        <div className="action">
-          <span className="icon-star" />
-          <span className="action-counter">{favourites}</span>
-          <span className="action-label">Favourites</span>
-        </div>
+        {
+          !post.reactions && <div className="action">
+            <span className="icon-star" />
+            <span className="action-counter">{favourites}</span>
+            <span className="action-label">Favourites</span>
+          </div>
+        }
       </div>
     </div>
   );

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -162,14 +162,12 @@ export default function PostItem({
         </div>
       )}
       {
-        post.reactions && <div className="action-bar" style={{flexWrap: 'wrap'}}>
+        post.reactions && <div className="action-bar">
           {
-            post.reactions?.map((val, index) => <div key={index} className="emoji-reaction" style={{
-              backgroundColor: '#2a2c38', margin: '0.5rem', padding: '0.3rem', display: 'flex', alignItems: 'center', borderRadius: '5px'
-            }}>
-              { val.value && <span>{val.value}</span> }
-              { val.url && <img src={val.url} style={{maxWidth: '20px', objectFit: 'cover'}} /> }
-              <span style={{ marginLeft: '0.45rem' }}>{ val.count }</span>
+            post.reactions?.map((val, index) => <div key={index} className="emoji-reaction">
+              { val.value && <span className="emoji-reaction-unicode">{val.value}</span> }
+              { val.url && <img className="emoji-reaction-custom" src={val.url} /> }
+              <span className="emoji-reaction-count">{ val.count }</span>
             </div>)
           }
         </div>

--- a/src/instance/Misskey.ts
+++ b/src/instance/Misskey.ts
@@ -1,8 +1,95 @@
 import { Post } from "../components/PostItem";
 import BaseInstance from "./BaseInstance";
 
-export default class MastodonInstance extends BaseInstance {
+interface MisskeyReaction {
+  [emojiName: string]: string | number;
+}
+
+interface MisskeyInstanceInterface {
+  name: string;
+  softwareName: string;
+  softwareVersion: string;
+  iconUrl: string;
+  faviconUrl: string;
+  themeColor: string;
+}
+
+interface MisskeyUser {
+  id: string;
+  name: string;
+  username: string;
+  host?: string;
+  avatarUrl: string;
+  avatarBlurhash: string;
+  isAdmin: boolean,
+  isModerator: boolean,
+  isBot?: boolean;
+  isCat?: boolean;
+  isLocked?: boolean;
+  speakAsCat?: boolean;
+  instance?: MisskeyInstanceInterface;
+  emojis: MisskeyReaction;
+}
+
+interface MisskeyFileProperty {
+  width: number;
+  height: number;
+  orientation: number;
+  avgColor: string
+}
+
+interface MisskeyFile {
+  id: string;
+  createdAt: string;
+  name: string;
+  type: string;
+  md5: string;
+  size: number;
+  isSensitive: boolean;
+  blurHash: string;
+  properties: MisskeyFileProperty;
+  url: string;
+  thumbnailUrl: string;
+  comment: string;
+  userId: string;
+  user: MisskeyUser;
+}
+
+interface MisskeyNotesResponse {
+  id: string;
+  createdAt: string;
+  deletedAt: string;
+  text: string;
+  cw: string;
+  userId: string;
+  user: MisskeyUser;
+  replyId?: string;
+  renoteId?: string;
+  reply?: MisskeyNotesResponse; 
+  renote?: MisskeyNotesResponse;
+  isHidden: boolean;
+  visibility: string;
+  mentions: string[];
+  visibleUserIds: string[]
+  fileIds: string[]
+  files: MisskeyFile[];
+  tags: string;
+  channelId: string;
+  channel: object;
+  localOnly: boolean;
+  reactions: MisskeyReaction;
+  reactionsEmoji: MisskeyReaction;
+  renoteCount: number;
+  repliesCount: number;
+  emojis: MisskeyReaction;
+  uri?: string;
+  url?: string;
+}
+
+export default class MisskeyInstance extends BaseInstance {
   public async execute(): Promise<Post> {
+    // TODO: instance/api/notes/show [POST]
+    // TODO: instance/api/users/show [POST] [If there's mentions over there]
     throw new Error("Misskey/Firefish is not supported yet.")
   }
 }

--- a/src/instance/Misskey.ts
+++ b/src/instance/Misskey.ts
@@ -1,5 +1,8 @@
-import { Post } from "../components/PostItem";
+import { AxiosError } from "axios";
+import { Attachment, Post } from "../components/PostItem";
+import { truncateString } from "../utils/util";
 import BaseInstance from "./BaseInstance";
+import { axiosInstance } from "../utils/axios";
 
 interface MisskeyReaction {
   [emojiName: string]: string | number;
@@ -90,6 +93,57 @@ export default class MisskeyInstance extends BaseInstance {
   public async execute(): Promise<Post> {
     // TODO: instance/api/notes/show [POST]
     // TODO: instance/api/users/show [POST] [If there's mentions over there]
-    throw new Error("Misskey/Firefish is not supported yet.")
+    if (this.url.protocol !== 'https:')
+      throw new Error("Protocol must be HTTPS");
+
+    try {
+      const uri = new URL(`https://${this.url.host}/api/notes/show`);
+      const note = await axiosInstance.post(uri.toString(), { noteId: this.postId });
+      const dataNote: MisskeyNotesResponse = note.data;
+
+      console.log(dataNote);
+
+      const username = `@${dataNote.user.username}@${this.url.host}`
+
+      const attachments: Attachment[] = dataNote.files.map(val => {
+        return {
+          type: 'image',
+          url: val.url,
+          aspectRatio: 1,
+          description: val.comment
+        }
+      });
+      console.log(attachments);
+
+      return {
+        username,
+        attachments,
+        displayName: dataNote.user.name,
+        plainUsername: dataNote.user.username,
+        avatarUrl: dataNote.user.avatarUrl,
+        content: dataNote.text,
+        boosts: dataNote.renoteCount,
+        comments: dataNote.repliesCount,
+        favourites: this.parseReactionToFavourites(dataNote.reactions),
+        date: new Date(dataNote.createdAt)
+      }
+    } catch (e) {
+      if (e instanceof AxiosError) {
+        if (!e.response) throw new Error("Failed to reach API");
+        if (e.response.status === 404)
+          throw new Error("Post not found. Is it private?");
+      }
+      throw new Error("Unknown error trying to reach Misskey instance");
+    }
+  }
+
+  // TODO: Can you change this to reaction list like Misskey things?
+  private parseReactionToFavourites(reaction: MisskeyReaction): number {
+    let count = 0;
+    Object.keys(reaction).forEach(react => {
+      if (typeof reaction[react] !== 'number') return;
+      count += reaction[react] as number;
+    });
+    return count;
   }
 }

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -311,3 +311,25 @@
     color: var(--color-button);
   }
 }
+
+.action-bar {
+  flex-wrap: wrap; 
+
+  .emoji-reaction {
+    align-items: center;
+    background-color: #2a2c38;
+    border-radius: 5px;
+    display: flex;
+    margin: 0.5rem;
+    padding: 0.3rem;
+
+    .emoji-reaction-custom {
+      max-width: 20px;
+      object-fit: cover;
+    }
+
+    .emoji-reaction-count {
+      margin-left: 0.45rem;
+    }
+  }
+}


### PR DESCRIPTION
# Description
Add some compatibility to showing Misskey notes (with reaction ofc!). The styling maybe it still rough due to my lack of Frontend brain, you can more improve it for that. Heavily debugging in Misskey instance instead of Firefish so you can check it some API differences before merge on it.

Some note for it:
- This pull request didn't implement Quote and Poll feature for now.
- Crossing Misskey instance is not supported due to inconsistency Misskey API for instance switching.
- Another Misskey JP boogaloo problematic, the dynamic-width-but-fixed-height-react
![image](https://github.com/raikasdev/mastopoet/assets/32958839/eb8a7846-f78e-4b5d-9f59-7673ff0d4856)

## Example
[Source Post](https://misskey.io/notes/9ir4mro70y) 
![mastopoet-_y_kuroki_-23082023](https://github.com/raikasdev/mastopoet/assets/32958839/1c88e254-ec62-4ab3-8977-c0ee8646917d)

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)